### PR TITLE
Allow image type of thumbnail created to be specified

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,16 @@
 Revision history for Catalyst-View-Thumbnail
 
+0.03    28 September 2015
+
+        Allow the overriding of the generated image file type via $c->stash->{image_type}.
+
+        This allows you to set all thumbnails generated to jpegs for example.
+        
+
+0.02    09 July 2015
+
+        Fixed test issues.
+
 0.01    04 September 2009 - 14:28
         Initial public release
 

--- a/lib/Catalyst/View/Thumbnail.pm
+++ b/lib/Catalyst/View/Thumbnail.pm
@@ -24,7 +24,7 @@ sub process {
   # or an error message on failure.
   
   if (UNIVERSAL::isa($image, 'Imager')) {
-    my $mime_type = image_info(\$c->stash->{image})->{file_media_type};
+    my $mime_type = $c->stash->{image_type} || image_info(\$c->stash->{image})->{file_media_type};
     (my $file_type = $mime_type) =~ s!^image/!!;
 
     my $thumbnail;

--- a/lib/Catalyst/View/Thumbnail.pm
+++ b/lib/Catalyst/View/Thumbnail.pm
@@ -195,6 +195,14 @@ the source image as necessary.
 
 This parameter is optional, and will default to 'fill' if omitted.
 
+=item image_type
+
+Mime type for the output image.  This is normally the same as the input image.
+If you set this the Imager library will produce an image of that format.  This
+is useful when you want to convert something like a tiff to a jpeg.  Note
+that the conversions can be strange so this may not be a good idea for all images.
+See the C<Imager> documentation for more details.
+
 =back
 
 =head2 Image formats


### PR DESCRIPTION
This allows for the caller to specify that they want a particular image type to be emitted.
